### PR TITLE
Check what platform OpenTK is running on

### DIFF
--- a/OFC/GL/GLStatics.cs
+++ b/OFC/GL/GLStatics.cs
@@ -31,12 +31,26 @@ namespace GLOFC
         [DllImport("opengl32.dll", EntryPoint = "wglGetCurrentContext")]
         extern static IntPtr wglGetCurrentContext();// DCAl
 
+        [DllImport("libGL.so.1", EntryPoint = "glXGetCurrentContext")]
+        public static extern IntPtr glxGetCurrentContext();
+
         /// <summary>
         /// Get the currentopenGL rendering context handle.
         /// </summary>
         public static IntPtr GetContext()
         {
-            return wglGetCurrentContext();
+            if (OpenTK.Configuration.RunningOnWindows)
+            {
+                return wglGetCurrentContext();
+            }
+            else if (OpenTK.Configuration.RunningOnX11)
+            {
+                return glxGetCurrentContext();
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
         }
 
         /// <summary>

--- a/OFC/WinForm/GLWinFormControl.cs
+++ b/OFC/WinForm/GLWinFormControl.cs
@@ -213,7 +213,7 @@ namespace GLOFC.WinForm
 
         private Point FindCursorFormCoords()
         {
-            UnsafeNativeMethods.GetCursorPos(out UnsafeNativeMethods.POINT p);
+            var p = Cursor.Position;
             Point gcsp = glControl.PointToScreen(new Point(0, 0));
             return new Point(p.X - gcsp.X, p.Y - gcsp.Y);
         }


### PR DESCRIPTION
This should fix the DLL Not Found exception when attempting to run under Linux, as seen in EDDiscovery/EDDiscovery#3338